### PR TITLE
Added a missing terminal symbol

### DIFF
--- a/FPM/sequences/ysequences.tex
+++ b/FPM/sequences/ysequences.tex
@@ -975,7 +975,7 @@ more sequences in $\bD$.
             \Tb{(1,4)}\ncput*{$AGT\$$}
             \pstree[]{\TC*\ncput*{$G$}}{%
               \Tb{(1,2)}\ncput*{$AAGT\$$}
-              \Tb{(1,5)}\ncput*{$T$}
+              \Tb{(1,5)}\ncput*{$T\$$}
             }
           }
           \tspace{0.2}


### PR DESCRIPTION
Adds the missing terminal symbol for suffix tree construction example on page 21.
Figure (f) j=6, branch (1,5) => T$